### PR TITLE
Increase compute engine and storage capacity

### DIFF
--- a/cloud-data/components/cloudResources.js
+++ b/cloud-data/components/cloudResources.js
@@ -1,31 +1,32 @@
-import * as React from 'react';
-import IntegerStep from './integerStep';
-import { Typography, Row, Col } from 'antd';
+import * as React from "react";
+import IntegerStep from "./integerStep";
+import { Typography, Row, Col } from "antd";
 
 const { Title } = Typography;
 const engineMarks = {
-  5: '5',
-  10: '10',
-  15: '15',
-  20: '20'
+  5: "5",
+  10: "10",
+  20: "20",
+  30: "30"
 };
 const storageMarks = {
-  200: '200',
-  400: '400',
-  600: '600',
-  800: '800'
+  1: "1",
+  5: "5",
+  10: "10",
+  20: "20",
+  30: "30"
 };
 const operationMarks = {
-  20: '20',
-  40: '40',
-  60: '60',
-  80: '80',
-  100: '100'
+  20: "20",
+  40: "40",
+  60: "60",
+  80: "80",
+  100: "100"
 };
 const computeEngineMin = 0;
-const computeEngineMax = 20;
+const computeEngineMax = 30;
 const diskMin = 0;
-const diskMax = 1000;
+const diskMax = 30;
 const operationMin = 0;
 const operationMax = 100;
 
@@ -33,7 +34,7 @@ function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-const computeEngineTiers = ['small', 'medium', 'large'];
+const computeEngineTiers = ["small", "medium", "large"];
 
 export default class CloudResources extends React.Component {
   state = {
@@ -74,11 +75,15 @@ export default class CloudResources extends React.Component {
     ));
 
     return (
-      <div className="App" style={{ fontSize: 12, marginTop: 20}}>
-        <Title level={4} style={{ marginBottom: 20, textAlign: 'center' }}>Compute Engines</Title>
+      <div className="App" style={{ fontSize: 12, marginTop: 20 }}>
+        <Title level={4} style={{ marginBottom: 20, textAlign: "center" }}>
+          Compute Engines
+        </Title>
         {computeEngine}
         <br />
-        <Title level={4} style={{ marginBottom: 20, textAlign: 'center' }}>Storage</Title>
+        <Title level={4} style={{ marginBottom: 20, textAlign: "center" }}>
+          Storage
+        </Title>
         <Row type="flex" justify="center">
           <Col span={4}>Capacity</Col>
           <Col span={16}>
@@ -87,11 +92,11 @@ export default class CloudResources extends React.Component {
               max={diskMax}
               marks={storageMarks}
               selectedValue={value =>
-                this.onStorageInputChange({ type: 'disk', value, os })
+                this.onStorageInputChange({ type: "disk", value, os })
               }
             />
           </Col>
-          <Col span={4}>GB</Col>
+          <Col span={4}>TB</Col>
         </Row>
         <Row type="flex" justify="center" style={{ marginBottom: 40 }}>
           <Col span={4}>Operation</Col>
@@ -101,7 +106,7 @@ export default class CloudResources extends React.Component {
               max={operationMax}
               marks={operationMarks}
               selectedValue={value =>
-                this.onStorageInputChange({ type: 'operation', value, os })
+                this.onStorageInputChange({ type: "operation", value, os })
               }
             />
           </Col>

--- a/cloud-data/components/cloudReview.js
+++ b/cloud-data/components/cloudReview.js
@@ -105,10 +105,11 @@ export default class CloudReview extends React.Component {
   }
 
   onStorageSelected = ({ type, value, os }) => {
-    const storagePrice =
+    var storagePricePerGb =
       type === "disk"
         ? this.state.azureCalculateData.storage.smallDiskPrice
         : this.state.azureCalculateData.storage.operationPrices;
+    var storagePrice = storagePricePerGb * 1024;
 
     const priceValue = storagePrice * value;
     let newPrice = { ...this.state.pricingData[os].price };
@@ -116,8 +117,10 @@ export default class CloudReview extends React.Component {
     newPrice[type] = round(priceValue, 2);
     newSelected[type] = value;
 
-    const awsStoragePrice =
+    var awsStoragePricePerGb =
       type === "disk" ? this.state.awsCalculateData.storage.pricePerGb : 0;
+    var awsStoragePrice = awsStoragePricePerGb * 1024;
+
     const awsPriceValue = awsStoragePrice * value;
     let awsNewPrice = { ...this.state.awsPricingData[os].price };
     let awsNewSelected = { ...this.state.awsPricingData[os].selectedValue };
@@ -181,10 +184,17 @@ export default class CloudReview extends React.Component {
     }
     return (
       <div className="App">
-        <Title level={2} style={{ textAlign: 'center' }}>Choose your cloud resources</Title>
+        <Title level={2} style={{ textAlign: "center" }}>
+          Choose your cloud resources
+        </Title>
         <Row style={{ marginTop: 40 }}>
           <Col span={12}>
-            <Title level={4} style={{ fontWeight: 'bold', textAlign: 'center' }}>Window</Title>
+            <Title
+              level={4}
+              style={{ fontWeight: "bold", textAlign: "center" }}
+            >
+              Window
+            </Title>
             <CloudResources
               os="windows"
               //platform
@@ -193,7 +203,12 @@ export default class CloudReview extends React.Component {
             />
           </Col>
           <Col span={12}>
-            <Title level={4} style={{ fontWeight: 'bold', textAlign: 'center' }}>Linux</Title>
+            <Title
+              level={4}
+              style={{ fontWeight: "bold", textAlign: "center" }}
+            >
+              Linux
+            </Title>
             <CloudResources
               os="linux"
               onComputeSelected={this.onComputeSelected}
@@ -218,7 +233,7 @@ export default class CloudReview extends React.Component {
               onClick={this.props.onContinueSelected}
             >
               Continue
-                </Button>
+            </Button>
           </Col>
         </Row>
       </div>

--- a/cloud-data/components/pricingCard.js
+++ b/cloud-data/components/pricingCard.js
@@ -21,7 +21,12 @@ export default class PricingCard extends React.Component {
     let total = 0;
 
     return (
-      <Card bordered={false} title={platform} style={{ textAlign: "center" }} headStyle={{ fontWeight: 'bold' }}>
+      <Card
+        bordered={false}
+        title={platform}
+        style={{ textAlign: "center" }}
+        headStyle={{ fontWeight: "bold" }}
+      >
         {Object.keys(cards).map(key => {
           const data = cards[key];
           const { selectedValue, price } = data;
@@ -67,14 +72,21 @@ export default class PricingCard extends React.Component {
               <Row type="flex" justify="center">
                 <Col span={6}>Capacity</Col>
                 <Col span={4}>{selectedValue.disk}</Col>
-                <Col span={7}>GB</Col>
+                <Col span={7}>TB</Col>
                 <Col span={5}>${price.disk.toLocaleString()}</Col>
               </Row>
               <Row type="flex" justify="center">
                 <Col span={6}>Operation</Col>
-                <Col span={4}>{platform === "AWS" ? "N/A" : selectedValue.operation}</Col>
+                <Col span={4}>
+                  {platform === "AWS" ? "N/A" : selectedValue.operation}
+                </Col>
                 <Col span={7}>times</Col>
-                <Col span={5}>${platform === "AWS" ? "N/A" : price.operation.toLocaleString()}</Col>
+                <Col span={5}>
+                  $
+                  {platform === "AWS"
+                    ? "N/A"
+                    : price.operation.toLocaleString()}
+                </Col>
               </Row>
             </Card>
           );


### PR DESCRIPTION
Increase the number of maximum compute engine from 20 to 30
Change storage capacity from GB to TB to allow users to pick  up to 30TB of storage (storage capacity for large t-shirt was 27TB so I think this was appropriate)
Change storagePrice from perGb to perTB to support the change above.
